### PR TITLE
fix: an issue where multiple containers in the same pod got the same container id

### DIFF
--- a/cmd/dnsproxy/main.go
+++ b/cmd/dnsproxy/main.go
@@ -68,7 +68,7 @@ func CreateDaemonServiceClient(sourceId *proto.SourceId) proto.NodeDaemonService
 	} else {
 		var err error
 		fmt.Printf("connecting to grpc at %s\n", daemonProxy)
-		nsId, err := linux.GetNetNsId(int32(os.Getpid()))
+		nsId, err := linux.GetMntNsId(int32(os.Getpid()))
 		if err != nil {
 			panic(err)
 		}
@@ -97,7 +97,7 @@ func main() {
 	}
 	sourceId := &proto.SourceId{
 		Type: "container",
-		Id:   hostname,
+		Id:   hostname + "-" + os.Getenv(consts.ContainerNameEnv),
 	}
 	client := CreateDaemonServiceClient(sourceId)
 	search, err := retrieveSearchList()

--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -23,6 +23,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/google/containerdbg/pkg/consts"
 	"github.com/google/containerdbg/pkg/daemon"
 	"github.com/google/containerdbg/pkg/dnsproxy"
 	"github.com/google/containerdbg/proto"
@@ -80,7 +81,7 @@ func xmain() error {
 	_, err = client.Monitor(context.Background(), &proto.MonitorPodRequest{
 		Id: &proto.SourceId{
 			Type: "container",
-			Id:   hostname,
+			Id:   hostname + "-" + os.Getenv(consts.ContainerNameEnv),
 		},
 	})
 	if err != nil {

--- a/cmd/node-daemon/daemon.go
+++ b/cmd/node-daemon/daemon.go
@@ -16,13 +16,13 @@ package main
 
 import (
 	"github.com/go-logr/logr"
-	"golang.org/x/net/context"
-	"google.golang.org/grpc/peer"
 	"github.com/google/containerdbg/pkg/ebpf"
 	"github.com/google/containerdbg/pkg/events"
 	"github.com/google/containerdbg/pkg/events/sources"
 	"github.com/google/containerdbg/pkg/linux"
 	"github.com/google/containerdbg/proto"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc/peer"
 )
 
 type NodeDaemonServiceServer struct {
@@ -56,7 +56,7 @@ func (srv *NodeDaemonServiceServer) Monitor(ctx context.Context, request *proto.
 		authInfo := UnixAuthFromContext(ctx)
 		log.Info("Got request from", "authInfo", authInfo)
 		pid := authInfo.creds.Pid
-		nsId, err = linux.GetNetNsId(pid)
+		nsId, err = linux.GetMntNsId(pid)
 		if err != nil {
 			return nil, err
 		}
@@ -81,11 +81,11 @@ func (srv *NodeDaemonServiceServer) ReportDnsQuery(ctx context.Context, request 
 		authInfo := UnixAuthFromContext(ctx)
 		pid := authInfo.creds.Pid
 
-		netns, err := linux.GetNetNsId(pid)
+		mntns, err := linux.GetMntNsId(pid)
 		if err != nil {
 			return nil, err
 		}
-		source = ebpf.GetManagerInstance().GetId(uint32(netns))
+		source = ebpf.GetManagerInstance().GetId(uint32(mntns))
 	}
 
 	log.Info("got dns event", "event", request)

--- a/examples/normal_deployment.yaml
+++ b/examples/normal_deployment.yaml
@@ -35,6 +35,9 @@ spec:
       - image: ko.local/test-openfile
         imagePullPolicy: IfNotPresent
         name: openfile-deployment
+      - image: ko.local/test-openfile
+        imagePullPolicy: IfNotPresent
+        name: openfile-deployment2
 
 ---
 # Headless Service specification -

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -15,6 +15,7 @@
 package consts
 
 const SharedDirectoryEnv = "SHARED_DIRECTORY"
+const ContainerNameEnv = "CONTAINER_NAME"
 const NodeDaemonSocketName = "node.sock"
 const ContainerdbgNamespace = "containerdbg-system"
 const ContainerdbgDaemonsetName = "containerdbg-daemonset"

--- a/pkg/debug/image.go
+++ b/pkg/debug/image.go
@@ -16,6 +16,7 @@ package debug
 
 import (
 	"github.com/google/containerdbg/pkg/build"
+	"github.com/google/containerdbg/pkg/consts"
 	"github.com/google/containerdbg/pkg/imagehelpers"
 	"github.com/google/containerdbg/pkg/rand"
 	appsv1 "k8s.io/api/apps/v1"
@@ -103,6 +104,14 @@ func modifyContainer(container *v1.Container) error {
 		return err
 	}
 	container.Command = append([]string{"/.containerdbg/entrypoint"}, result...)
+	if container.Env == nil {
+		container.Env = []v1.EnvVar{}
+	}
+
+	container.Env = append(container.Env, v1.EnvVar{
+		Name:  consts.ContainerNameEnv,
+		Value: container.Name,
+	})
 	return nil
 }
 

--- a/pkg/ebpf/file_opens_filter.c
+++ b/pkg/ebpf/file_opens_filter.c
@@ -153,7 +153,7 @@ static int exit_open_common(void *ctx, u64 ret) {
     bpf_map_delete_elem(&filename_map, &tid);
     return 0;
   }
-  event->netns = get_current_net_ns();
+  event->netns = get_current_ns();
   event->tid = tid;
   event->ret = ret;
   event->ts = bpf_ktime_get_ns();

--- a/pkg/ebpf/filter_manager.go
+++ b/pkg/ebpf/filter_manager.go
@@ -111,7 +111,7 @@ func (mgr *filtersManager) Init() error {
 
 func (mgr *filtersManager) RegisterContainer(nsId uint32, id *proto.SourceId) error {
 	mgr.idMap.Store(nsId, id)
-	if err := mgr.pinnedMaps.NetNs.Put(nsId, uint8(1)); err != nil {
+	if err := mgr.pinnedMaps.FollowNs.Put(nsId, uint8(1)); err != nil {
 		mgr.idMap.Delete(nsId)
 		return err
 	}

--- a/pkg/ebpf/headers/common.h
+++ b/pkg/ebpf/headers/common.h
@@ -24,17 +24,17 @@ struct {
   __uint(value_size, sizeof(u8));
   __uint(max_entries, 1 << 10);
   __uint(pinning, LIBBPF_PIN_BY_NAME);
-} net_ns SEC(".maps");
+} follow_ns SEC(".maps");
 
-static u32 get_current_net_ns() {
+static u32 get_current_ns() {
   struct task_struct *curtask = (struct task_struct *)bpf_get_current_task();
 
-  return BPF_CORE_READ(curtask, nsproxy, net_ns, ns.inum);
+  return BPF_CORE_READ(curtask, nsproxy, mnt_ns, ns.inum);
 }
 
 static inline bool is_correct_namespace() {
-  u32 current_ns = get_current_net_ns();
-  u8 *expected_ns = (u8 *)bpf_map_lookup_elem(&net_ns, &current_ns);
+  u32 current_ns = get_current_ns();
+  u8 *expected_ns = (u8 *)bpf_map_lookup_elem(&follow_ns, &current_ns);
   if (expected_ns == NULL) {
     return false;
   }

--- a/pkg/ebpf/netstate_filter.c
+++ b/pkg/ebpf/netstate_filter.c
@@ -145,7 +145,7 @@ int trace_inet_sock_set_state(
     struct event_t e = {};
     e.last_state = oldstate;
     e.new_state = newstate;
-    e.netns = get_current_net_ns();
+    e.netns = get_current_ns();
     e.tid = tid;
     e.ts = bpf_ktime_get_ns();
     bpf_get_current_comm(&e.comm, sizeof(e.comm));

--- a/pkg/ebpf/renamelink_filter.c
+++ b/pkg/ebpf/renamelink_filter.c
@@ -185,7 +185,7 @@ int sys_exit_rename(struct exit_rename_info *info) {
     return 0;
   }
 
-  event->netns = get_current_net_ns();
+  event->netns = get_current_ns();
   event->tid = tid;
   event->ret = info->ret;
   event->ts = bpf_ktime_get_ns();

--- a/pkg/linux/utils.go
+++ b/pkg/linux/utils.go
@@ -21,8 +21,8 @@ import (
 	"syscall"
 )
 
-func GetNetNsId(pid int32) (uint64, error) {
-	info, err := os.Stat(fmt.Sprintf("/proc/%d/ns/net", pid))
+func GetMntNsId(pid int32) (uint64, error) {
+	info, err := os.Stat(fmt.Sprintf("/proc/%d/ns/mnt", pid))
 	if err != nil {
 		return 0, err
 	}

--- a/test/component/file_opens_filter_test.go
+++ b/test/component/file_opens_filter_test.go
@@ -49,7 +49,7 @@ func runBinaryWithNewNSAndAttach(t *testing.T, path string, args []string, exitC
 		t.Fatal("failed to run test binary", err)
 	}
 
-	netId, err := linux.GetNetNsId(int32(cmd.Process.Pid))
+	netId, err := linux.GetMntNsId(int32(cmd.Process.Pid))
 	if err != nil {
 		t.Fatal("failed to get namespace of command", err)
 	}


### PR DESCRIPTION

This was due to os.Hostname() returning the name of the pod and not the container as was assumed, container name is now passed to the debugged container through CONTAINER_NAME env variable.

Furthermore moved to use mount namespace to differentiate containers as network namespace is shared by all containers in a pod.