### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -18,8 +18,8 @@ jobs:
         check-latest: true
     - id: go-cache-paths
       run: |
-        echo "::set-output name=go-build::$(go env GOCACHE)"
-        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+        echo "go-build=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+        echo "go-mod=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
     - name: Go Build Cache
       uses: actions/cache@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         name: 'kpt'
     - name: Set tag
       id: vars
-      run: echo "::set-output name=tag::${GITHUB_REF#refs/*/}"
+      run: echo "tag=${GITHUB_REF#refs/*/}" >> "$GITHUB_OUTPUT"
     - name: generate
       env:
         TARGET_REPO: europe-docker.pkg.dev/migrate-modernize-public/containerdbg
@@ -48,7 +48,7 @@ jobs:
       run: |
         set -euo pipefail
         checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
-        echo "::set-output name=hashes::$(cat $checksum_file | base64 -w0)"
+        echo "hashes=$(cat $checksum_file | base64 -w0)" >> "$GITHUB_OUTPUT"
 
   provenance:
     needs: [goreleaser]


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter